### PR TITLE
fix: removing commitlint from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: 0

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,6 @@
 export default {
   extends: ["@commitlint/config-conventional"],
+  ignores: [(message) => /^chore\(release\):/.test(message)],
   rules: {
     "type-enum": [
       2,


### PR DESCRIPTION
## Description

removing commitlint from being executed in releases

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Linting passes (`npm run lint`)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] I have updated CHANGELOG.md
