### PR TITLE
fix: updating document icon import to match new Sanity pattern

### DIFF
--- a/src/structure/index.ts
+++ b/src/structure/index.ts
@@ -1,4 +1,4 @@
-import { DocumentIcon } from "@sanity/icons";
+import { DocumentIcon } from "@sanity/icons/Document";
 import type { ListItemBuilder } from "sanity/structure";
 
 import { getSingletonDocuments } from "../helpers";


### PR DESCRIPTION
## Description

Updated DocumentIcon import in the structure page to match new pattern: `import { DocumentIcon } from "@sanity/icons/Document";`

Addresses #183 

## Type of Change

- [ ] Dependancy update(s)
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Testing

- [X] Tests pass (`npm test`)
- [X] Build succeeds (`npm run build`)
- [X] Linting passes (`npm run lint`)

## Checklist

- [X] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] I have added tests for new functionality
